### PR TITLE
Time cheatcodes

### DIFF
--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -8,6 +8,16 @@ abstract contract stdCheats {
     // we use a custom name that is unlikely to cause collisions so this contract
     // can be inherited easily
     Vm constant vm_std_cheats = Vm(address(bytes20(uint160(uint256(keccak256('hevm cheat code'))))));
+
+    // Skip forward or rewind time by the specified number of seconds
+    function skip(uint256 time) public {
+        vm_std_cheats.warp(block.timestamp + time);
+    }
+
+    function rewind(uint256 time) public {
+        vm_std_cheats.warp(block.timestamp - time);
+    }
+
     // Setup a prank from an address that has some ether
     function hoax(address who) public {
         vm_std_cheats.deal(who, 1 << 128);

--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -7,7 +7,7 @@ import "./Vm.sol";
 abstract contract stdCheats {
     // we use a custom name that is unlikely to cause collisions so this contract
     // can be inherited easily
-    Vm constant vm_std_cheats = Vm(address(bytes20(uint160(uint256(keccak256('hevm cheat code'))))));
+    Vm constant vm_std_cheats = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
 
     // Skip forward or rewind time by the specified number of seconds
     function skip(uint256 time) public {
@@ -96,7 +96,7 @@ library stdStorage {
     event SlotFound(address who, bytes4 fsig, bytes32 keysHash, uint slot);
     event WARNING_UninitedSlot(address who, uint slot);
     
-    Vm constant stdstore_vm = Vm(address(bytes20(uint160(uint256(keccak256('hevm cheat code'))))));
+    Vm constant stdstore_vm = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
 
     function sigs(
         string memory sigStr

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -13,6 +13,18 @@ contract StdCheatsTest is DSTest, stdCheats {
         test = new Bar();
     }
 
+    function testSkip() public {
+        vm.warp(100);
+        skip(25);
+        assertEq(block.timestamp, 125);
+    }
+
+    function testRewind() public {
+        vm.warp(100);
+        rewind(25);
+        assertEq(block.timestamp, 75);
+    }
+
     function testHoax() public {
         hoax(address(1337));
         test.bar{value: 100}(address(1337));


### PR DESCRIPTION
- Adds `skip` and `rewind` stdcheats. Saw these mentioned in the foundry telegram and know others who have requested them, so figured I'd PR them in
- Also removed an unnecessary cast when computing the cheat code address