### PR TITLE
add deployCode helper

### DIFF
--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -64,7 +64,7 @@ abstract contract stdCheats {
 
     // Deploys a contract by fetching the contract bytecode from
     // the artifacts directory
-    function transcribe(string memory what, bytes memory args)
+    function deployCode(string memory what, bytes memory args)
         public
         returns (address addr)
     {
@@ -74,7 +74,7 @@ abstract contract stdCheats {
         }
     }
 
-    function transcribe(string memory what)
+    function deployCode(string memory what)
         public
         returns (address addr)
     {

--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -61,6 +61,28 @@ abstract contract stdCheats {
         vm_std_cheats.deal(who, give);
         vm_std_cheats.startPrank(who, origin);
     }
+
+    // Deploys a contract by fetching the contract bytecode from
+    // the artifacts directory
+    function transcribe(string memory what, bytes memory args)
+        public
+        returns (address addr)
+    {
+        bytes memory bytecode = abi.encodePacked(vm_std_cheats.getCode(what), args);
+        assembly {
+            addr := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+    }
+
+    function transcribe(string memory what)
+        public
+        returns (address addr)
+    {
+        bytes memory bytecode = vm_std_cheats.getCode(what);
+        assembly {
+            addr := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+    }
 }
 
 

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -50,6 +50,16 @@ contract StdCheatsTest is DSTest, stdCheats {
         vm.stopPrank();
         test.bar(address(this));
     }
+
+    function testTranscribe() public {
+        address deployed = transcribe("StdCheats.t.sol:StdCheatsTest", bytes(""));
+        assertEq(string(deployed.code), string(address(this).code));
+    }
+
+    function testTranscibeNoArgs() public {
+        address deployed = transcribe("StdCheats.t.sol:StdCheatsTest");
+        assertEq(string(deployed.code), string(address(this).code));
+    }
 }
 
 contract Bar {

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -51,13 +51,13 @@ contract StdCheatsTest is DSTest, stdCheats {
         test.bar(address(this));
     }
 
-    function testTranscribe() public {
-        address deployed = transcribe("StdCheats.t.sol:StdCheatsTest", bytes(""));
+    function testDeployCode() public {
+        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""));
         assertEq(string(deployed.code), string(address(this).code));
     }
 
-    function testTranscibeNoArgs() public {
-        address deployed = transcribe("StdCheats.t.sol:StdCheatsTest");
+    function testDeployCodeNoArgs() public {
+        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest");
         assertEq(string(deployed.code), string(address(this).code));
     }
 }


### PR DESCRIPTION
Adds helpers to make deployment using `vm.getCode` easier. At some point I would like to add a third overload where you can specify the address that the contract will be deployed at, but I think this will require some extra functionality to make constructors work properly.