### PR TITLE
build(solc): semver fix

### DIFF
--- a/src/test/StdError.t.sol
+++ b/src/test/StdError.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity 0.8.10;
+pragma solidity >=0.6.0 <0.9.0;
 
 import "ds-test/test.sol";
 import {stdError} from "../stdlib.sol";


### PR DESCRIPTION
this expands the versioning to the same version you used throughout the contracts