### PR TITLE
hoax fix

### DIFF
--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -31,12 +31,12 @@ abstract contract stdCheats {
 
     function hoax(address who, address origin) public {
         vm_std_cheats.deal(who, 1 << 128);
-        vm_std_cheats.prank(who, who);
+        vm_std_cheats.prank(who, origin);
     }
 
     function hoax(address who, address origin, uint256 give) public {
         vm_std_cheats.deal(who, give);
-        vm_std_cheats.prank(who, who);
+        vm_std_cheats.prank(who, origin);
     }
 
     // Start perpetual prank from an address that has some ether

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -66,7 +66,7 @@ contract StdCheatsTest is DSTest, stdCheats {
         assertEq(string(getCode(deployed)), string(getCode(address(this))));
     }
 
-    function getCode(address who) internal returns (bytes memory o_code) {
+    function getCode(address who) internal view returns (bytes memory o_code) {
         assembly {
             // retrieve the size of the code, this needs assembly
             let size := extcodesize(who)

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -35,6 +35,11 @@ contract StdCheatsTest is DSTest, stdCheats {
         test.origin{value: 100}(address(1337));
     }
 
+    function testHoaxDifferentAddresses() public {
+        hoax(address(1337), address(7331));
+        test.origin{value: 100}(address(1337), address(7331));
+    }
+
     function testStartHoax() public {
         startHoax(address(1337));
         test.bar{value: 100}(address(1337));
@@ -85,5 +90,9 @@ contract Bar {
     function origin(address expectedSender) public payable {
         require(msg.sender == expectedSender, "!prank");
         require(tx.origin == expectedSender, "!prank");
+    }
+    function origin(address expectedSender, address expectedOrigin) public payable {
+        require(msg.sender == expectedSender, "!prank");
+        require(tx.origin == expectedOrigin, "!prank");
     }
 }


### PR DESCRIPTION
- fix bug in `hoax` methods that took separate `msg.sender` and `tx.origin` inputs, as they ignored the latter
- add `view` to silence compiler warning
- there's one outstanding compiler warning about removing `public` from the constructor declaration in `StdStorage.t.sol`, but if we do then it's no longer compatible with the `>=0.6.0` pragma, so left that one alone