### PR TITLE
feat: add `tip` stdcheat

### DIFF
--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -75,8 +75,8 @@ abstract contract stdCheats {
         vm_std_cheats.store(which, reads[0], bytes32(give));
     }
     
-    // If a token's `balanceOf` method does not return the balance immediately,
-    // you can pass the name of the mapping that holds the balances
+    // If a token's `balanceOf` method does not read the balance immediately,
+    // pass the name of the mapping that holds balances
     function tip(address which, string memory where, uint256 give, address to) public {
         uint256 slot = std_store_std_cheats
             .target(which)

--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -65,16 +65,16 @@ abstract contract stdCheats {
         vm_std_cheats.startPrank(who, origin);
     }
 
-    // Set the balance of an account for any token
+    // Allows you to set an account's balance for a majority of tokens
     // Be careful not to break something!
-    function tip(
-        address which,
-        uint256 give,
-        address to
-    ) public {
+    function tip(address which, uint256 give, address to) public {
+        tip(which, "balanceOf", give, to);
+    }
+
+    function tip(address which, string memory where, uint256 give, address to) public {
         uint256 slot = std_store_std_cheats
             .target(which)
-            .sig(0x70a08231)
+            .sig(bytes4(keccak256(abi.encodePacked(where, "(address)"))))
             .with_key(to)
             .find();
         vm_std_cheats.store(which, bytes32(slot), bytes32(give));

--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -68,9 +68,15 @@ abstract contract stdCheats {
     // Allows you to set an account's balance for a majority of tokens
     // Be careful not to break something!
     function tip(address which, uint256 give, address to) public {
-        tip(which, "balanceOf", give, to);
+        vm_std_cheats.record();
+        (bool sent, ) = which.call(abi.encodeWithSelector(0x70a08231, to));
+        require(sent, "Failed to access `balanceOf` method.");
+        (bytes32[] memory reads, ) = vm_std_cheats.accesses(which);
+        vm_std_cheats.store(which, reads[0], bytes32(give));
     }
-
+    
+    // If a token's `balanceOf` method does not return the balance immediately,
+    // you can pass the name of the mapping that holds the balances
     function tip(address which, string memory where, uint256 give, address to) public {
         uint256 slot = std_store_std_cheats
             .target(which)

--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -7,7 +7,7 @@ import "./Vm.sol";
 abstract contract stdCheats {
     using stdStorage for StdStorage;
 
-    // we use a custom names that are unlikely to cause collisions so this contract
+    // we use custom names that are unlikely to cause collisions so this contract
     // can be inherited easily
     Vm constant vm_std_cheats = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
     StdStorage std_store_std_cheats;

--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -68,7 +68,8 @@ abstract contract stdCheats {
     // Allows you to set the balance of an account for a majority of tokens
     // Be careful not to break something!
     function tip(address token, address to, uint256 give) public {
-        std_store_std_cheats.target(token)
+        std_store_std_cheats
+            .target(token)
             .sig(0x70a08231)
             .with_key(to)
             .checked_write(give);

--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -62,15 +62,15 @@ abstract contract stdCheats {
         vm_std_cheats.startPrank(who, origin);
     }
 
-    // Allows you to the balance of an account for a majority of tokens
+    // Allows you to set the balance of an account for a majority of tokens
     // Be careful not to break something!
-    function tip(address to, uint256 give, address which) public {
+    function tip(address token, address to, uint256 give) public {
         vm_std_cheats.record();
-        (bool sent, ) = which.call(abi.encodeWithSelector(0x70a08231, to));
-        require(sent, "Failed to access `balanceOf`.");
-        (bytes32[] memory reads, ) = vm_std_cheats.accesses(which);
-        vm_std_cheats.store(which, reads[0], bytes32(give));
-        ( , bytes memory data) = which.call(abi.encodeWithSelector(0x70a08231, to));
+        (bool sent, ) = token.call(abi.encodeWithSelector(0x70a08231, to));
+        require(sent, "Failed to access `balanceOf`. Make sure this is an ERC20 token.");
+        (bytes32[] memory reads, ) = vm_std_cheats.accesses(token);
+        vm_std_cheats.store(token, reads[0], bytes32(give));
+        ( , bytes memory data) = token.call(abi.encodeWithSelector(0x70a08231, to));
         require(uint256(bytes32(data)) == give, "Could not tip. You will have to set the balance manually.");
     }
 

--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -67,7 +67,7 @@ abstract contract stdCheats {
 
     // Allows you to set an account's balance for a majority of tokens
     // Be careful not to break something!
-    function tip(address which, uint256 give, address to) public {
+    function tip(address to, uint256 give, address which) public {
         vm_std_cheats.record();
         (bool sent, ) = which.call(abi.encodeWithSelector(0x70a08231, to));
         require(sent, "Failed to access `balanceOf` method.");
@@ -77,7 +77,7 @@ abstract contract stdCheats {
     
     // If a token's `balanceOf` method does not read the balance immediately,
     // pass the name of the mapping that holds balances
-    function tip(address which, string memory where, uint256 give, address to) public {
+    function tip(address to, uint256 give, address which, string memory where) public {
         uint256 slot = std_store_std_cheats
             .target(which)
             .sig(bytes4(keccak256(abi.encodePacked(where, "(address)"))))

--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -5,9 +5,12 @@ import "./Vm.sol";
 
 // Wrappers around Cheatcodes to avoid footguns
 abstract contract stdCheats {
-    // we use a custom name that is unlikely to cause collisions so this contract
+    using stdStorage for StdStorage;
+
+    // we use custom names that are unlikely to cause collisions so this contract
     // can be inherited easily
     Vm constant vm_std_cheats = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+    StdStorage std_store_std_cheats;
 
     // Skip forward or rewind time by the specified number of seconds
     function skip(uint256 time) public {
@@ -60,6 +63,21 @@ abstract contract stdCheats {
     function startHoax(address who, address origin, uint256 give) public {
         vm_std_cheats.deal(who, give);
         vm_std_cheats.startPrank(who, origin);
+    }
+
+    // Set the balance of an account for any token
+    // Be careful not to break something!
+    function tip(
+        address which,
+        uint256 give,
+        address to
+    ) public {
+        uint256 slot = std_store_std_cheats
+            .target(which)
+            .sig(0x70a08231)
+            .with_key(to)
+            .find();
+        vm_std_cheats.store(which, bytes32(slot), bytes32(give));
     }
 
     // Deploys a contract by fetching the contract bytecode from

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -62,6 +62,12 @@ contract StdCheatsTest is DSTest, stdCheats {
         assertEq(token.balanceOf(address(this)), 10000e18);
     }
 
+    function testTipAtypical() public {
+        Bar token = new Bar();
+        tip(address(token), "balanceOf", 10000e18, address(this));
+        assertEq(token.balanceOf(address(this)), 10000e18);
+    }
+
     function testDeployCode() public {
         address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""));
         assertEq(string(getCode(deployed)), string(getCode(address(this))));

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -57,15 +57,17 @@ contract StdCheatsTest is DSTest, stdCheats {
     }
 
     function testTip() public {
-        Bar token = new Bar();
-        tip(address(token), 10000e18, address(this));
-        assertEq(token.balanceOf(address(this)), 10000e18);
+        Bar barToken = new Bar();
+        address bar = address(barToken);
+        tip(address(this), 10000e18, bar);
+        assertEq(barToken.balanceOf(address(this)), 10000e18);
     }
 
     function testTipAtypical() public {
-        Bar token = new Bar();
-        tip(address(token), "balanceOf", 10000e18, address(this));
-        assertEq(token.balanceOf(address(this)), 10000e18);
+        Bar barToken = new Bar();
+        address bar = address(barToken);
+        tip(address(this), 10000e18, bar, "balanceOf");
+        assertEq(barToken.balanceOf(address(this)), 10000e18);
     }
 
     function testDeployCode() public {

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -63,11 +63,10 @@ contract StdCheatsTest is DSTest, stdCheats {
         assertEq(barToken.balanceOf(address(this)), 10000e18);
     }
 
-    function testTipAtypical() public {
-        Bar barToken = new Bar();
-        address bar = address(barToken);
-        tip(address(this), 10000e18, bar, "balanceOf");
-        assertEq(barToken.balanceOf(address(this)), 10000e18);
+    function testFailTip() public {
+        Baz bazToken = new Baz();
+        address baz = address(bazToken);
+        tip(address(this), 10000e18, baz);
     }
 
     function testDeployCode() public {
@@ -98,7 +97,7 @@ contract StdCheatsTest is DSTest, stdCheats {
 }
 
 contract Bar {
-    mapping (address => uint) public  balanceOf;
+    /// `HOAX` STDCHEATS
     function bar(address expectedSender) public payable {
         require(msg.sender == expectedSender, "!prank");
     }
@@ -109,5 +108,17 @@ contract Bar {
     function origin(address expectedSender, address expectedOrigin) public payable {
         require(msg.sender == expectedSender, "!prank");
         require(tx.origin == expectedOrigin, "!prank");
+    }
+    /// `TIP` STDCHEAT
+    mapping (address => uint256) public balanceOf;
+}
+
+contract Baz {
+    /// `TIP` STDCHEAT
+    uint256 something;
+    mapping (address => uint256) private balances;
+    function balanceOf(address account) public returns (uint256) {
+        something++;
+        return balances[account];
     }
 }

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -59,7 +59,7 @@ contract StdCheatsTest is DSTest, stdCheats {
     function testTip() public {
         Bar barToken = new Bar();
         address bar = address(barToken);
-        tip(address(this), 10000e18, bar);
+        tip(bar, address(this), 10000e18);
         assertEq(barToken.balanceOf(address(this)), 10000e18);
     }
 

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -56,6 +56,12 @@ contract StdCheatsTest is DSTest, stdCheats {
         test.bar(address(this));
     }
 
+    function testTip() public {
+        Bar token = new Bar();
+        tip(address(token), 10000e18, address(this));
+        assertEq(token.balanceOf(address(this)), 10000e18);
+    }
+
     function testDeployCode() public {
         address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""));
         assertEq(string(getCode(deployed)), string(getCode(address(this))));
@@ -84,6 +90,7 @@ contract StdCheatsTest is DSTest, stdCheats {
 }
 
 contract Bar {
+    mapping (address => uint) public  balanceOf;
     function bar(address expectedSender) public payable {
         require(msg.sender == expectedSender, "!prank");
     }

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -63,12 +63,6 @@ contract StdCheatsTest is DSTest, stdCheats {
         assertEq(barToken.balanceOf(address(this)), 10000e18);
     }
 
-    function testFailTip() public {
-        Baz bazToken = new Baz();
-        address baz = address(bazToken);
-        tip(address(this), 10000e18, baz);
-    }
-
     function testDeployCode() public {
         address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""));
         assertEq(string(getCode(deployed)), string(getCode(address(this))));
@@ -111,14 +105,4 @@ contract Bar {
     }
     /// `TIP` STDCHEAT
     mapping (address => uint256) public balanceOf;
-}
-
-contract Baz {
-    /// `TIP` STDCHEAT
-    uint256 something;
-    mapping (address => uint256) private balances;
-    function balanceOf(address account) public returns (uint256) {
-        something++;
-        return balances[account];
-    }
 }


### PR DESCRIPTION
Gm! This is a new `tip` stdcheat.

### Motivation
Simplify funding an account with a set amount of an arbitrary ERC20 token.

### Solution
A convenient solution you can use in tests:
```solidity
tip(alice, 10000e18, dai);

// Let's test it
assertEq(daiToken.balanceOf(alice), 10000e18); // [PASS]
```
Especially useful when forking.

Edit: Need to make a few changes to make it work with ~~every~~ a majority of tokens. **✔️ DONE**