### PR TITLE
fix: increase min solidity version to 0.7.0

### DIFF
--- a/src/test/StdStorage.t.sol
+++ b/src/test/StdStorage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity >=0.6.0 <0.9.0;
+pragma solidity >=0.7.0 <0.9.0;
 
 import "ds-test/test.sol";
 import "../stdlib.sol";


### PR DESCRIPTION
Previously StdStorage.t.sol claimed to support `pragma solidity >=0.6.0 <0.9.0;`.
However https://github.com/brockelmore/forge-std/pull/18 introduced a bug because it removed `public` from a constructor. This
feature was only added in [solidity 0.7.0](https://docs.soliditylang.org/en/v0.7.0/070-breaking-changes.html#functions-and-events).

> Visibility (`public` / `external`) is not needed for constructors anymore

So this change increases the minimum solidity version needed