### PR TITLE
2 commits: `lowLevelError` + `testExpectEncodeStg`

### DIFF
--- a/src/stdlib.sol
+++ b/src/stdlib.sol
@@ -109,6 +109,7 @@ library stdError {
     bytes public constant indexOOBError = abi.encodeWithSignature("Panic(uint256)", 0x32);
     bytes public constant memOverflowError = abi.encodeWithSignature("Panic(uint256)", 0x41);
     bytes public constant zeroVarError = abi.encodeWithSignature("Panic(uint256)", 0x51);
+    bytes public constant lowLevelError = bytes(""); // `0x`
 }
 
 struct StdStorage {

--- a/src/test/StdError.t.sol
+++ b/src/test/StdError.t.sol
@@ -58,6 +58,11 @@ contract StdErrorsTest is DSTest {
         test.intern();
     }
 
+    function testExpectLowLvl() public {
+        vm.expectRevert(stdError.lowLevelError);
+        test.someArr(0);
+    }
+
     // TODO: figure out how to trigger encodeStorageError?
 }
 
@@ -66,7 +71,7 @@ contract ErrorsTest {
         T1
     }
 
-    uint256[] someArr;
+    uint256[] public someArr;
 
     function assertionError() public pure {
         assert(false);

--- a/src/test/StdError.t.sol
+++ b/src/test/StdError.t.sol
@@ -38,6 +38,11 @@ contract StdErrorsTest is DSTest {
         test.enumConversion(1);
     }
 
+    function testExpectEncodeStg() public {
+        vm.expectRevert(stdError.encodeStorageError);
+        test.encodeStgError();
+    }
+
     function testExpectPop() public {
         vm.expectRevert(stdError.popError);
         test.pop();
@@ -72,6 +77,7 @@ contract ErrorsTest {
     }
 
     uint256[] public someArr;
+    bytes someBytes;
 
     function assertionError() public pure {
         assert(false);
@@ -91,6 +97,13 @@ contract ErrorsTest {
 
     function enumConversion(uint256 a) public pure {
         T(a);
+    }
+
+    function encodeStgError() public {
+        assembly {
+            sstore(someBytes.slot, 1)
+        }
+        bytes memory b = someBytes;
     }
 
     function pop() public {


### PR DESCRIPTION
# feat(stdError): add `lowLevelError`

### Motivation
Cover `INVALID opcode` cases, such as trying to directly access an element of an array in another contract that is oob, or when there was an error while decoding the error message (`0x`).

### Showcase with arrays
```solidity
contract C {
    bool[] public bools;

    constructor() {
        bools.push(true);
    }
}

contract TestC is DSTest {
    function testLowLevelError() public {
        Vm vm = Vm(HEVM_ADDRESS);
        C c = new C();
        // P.S. No, we cannot use `indexOOBError` here
        vm.expectRevert(stdError.lowLevelError);
        c.bools(1);
    }
}
```

<br>

# test(stdError): add `testExpectEncodeStg`

Add a test for `encodeStorageError`. This was marked as `TODO`.

```solidity
/// INSIDE TESTING CONTRACT

function testExpectEncodeStg() public {
    vm.expectRevert(stdError.encodeStorageError);
    test.encodeStgError();
}

/// INSIDE DUMMY CONTRACT

bytes someBytes;

function encodeStgError() public {
    assembly {
        sstore(someBytes.slot, 1)
    }
    bytes memory b = someBytes;
}
```